### PR TITLE
Move from Azure's Bing Speech Service To Azure's Speech Service (and one bug fix)

### DIFF
--- a/Sample/Xamarin.Cognitive.BingSpeech.Sample/Keys.cs
+++ b/Sample/Xamarin.Cognitive.BingSpeech.Sample/Keys.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Cognitive.BingSpeech.Sample
 		{
 			public const string BadSubscriptionKey = "!BAD KEY!"; // get a key here: https://azure.microsoft.com/en-us/try/cognitive-services/my-apis/?apiSlug=speech-api
 
-			public const string SubscriptionKey = "891d7678fde14d19b0a57e5a63a82404"; // replace with your own key here, e.g. "8a29574dc98a4a29566fa7f6440d3d39";
+			public const string SubscriptionKey = "BadSubscriptionKey"; // replace with your own key here, e.g. "8a29574dc98a4a29566fa7f6440d3d39";
 		}
 	}
 }

--- a/Sample/Xamarin.Cognitive.BingSpeech.Sample/Keys.cs
+++ b/Sample/Xamarin.Cognitive.BingSpeech.Sample/Keys.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Cognitive.BingSpeech.Sample
 		{
 			public const string BadSubscriptionKey = "!BAD KEY!"; // get a key here: https://azure.microsoft.com/en-us/try/cognitive-services/my-apis/?apiSlug=speech-api
 
-			public const string SubscriptionKey = BadSubscriptionKey; // replace with your own key here, e.g. "8a29574dc98a4a29566fa7f6440d3d39";
+			public const string SubscriptionKey = "891d7678fde14d19b0a57e5a63a82404"; // replace with your own key here, e.g. "8a29574dc98a4a29566fa7f6440d3d39";
 		}
 	}
 }

--- a/Sample/Xamarin.Cognitive.BingSpeech.Sample/MainPage.xaml
+++ b/Sample/Xamarin.Cognitive.BingSpeech.Sample/MainPage.xaml
@@ -3,6 +3,7 @@
     <Grid>
         <ScrollView Orientation="Vertical" VerticalOptions="FillAndExpand">
             <StackLayout Padding="20,80,20,0" Orientation="Vertical" Spacing="15">
+                <Picker x:Name="SpeechRegionPicker" Title="Choose Speech Region" ItemsSource="{Binding SpeechRegions}" SelectedItem="{Binding SpeechRegion}" SelectedIndexChanged="SpeechRegionPicker_SelectedIndexChanged" />
                 <Picker x:Name="RecognitionModePicker" Title="Choose Recognition Mode" ItemsSource="{Binding RecognitionModes}" SelectedItem="{Binding RecognitionMode}" />
                 <Picker x:Name="OutputModePicker" Title="Choose Output Mode" ItemsSource="{Binding OutputModes}" SelectedItem="{Binding OutputMode}" />
                 <Picker x:Name="ProfanityModePicker" Title="Choose Profanity Mode" ItemsSource="{Binding ProfanityModes}" SelectedItem="{Binding ProfanityMode}" />

--- a/Sample/Xamarin.Cognitive.BingSpeech.Sample/MainPage.xaml.cs
+++ b/Sample/Xamarin.Cognitive.BingSpeech.Sample/MainPage.xaml.cs
@@ -12,6 +12,10 @@ namespace Xamarin.Cognitive.BingSpeech.Sample
 		AudioRecorderService recorder;
 		BingSpeechApiClient speechClient;
 
+		public Array SpeechRegions => Enum.GetValues(typeof(SpeechRegion));
+
+		public SpeechRegion SpeechRegion { get; set; } = SpeechRegion.EastUS;
+
 		public Array AuthenticationModes => Enum.GetValues (typeof (AuthenticationMode));
 
 		public AuthenticationMode AuthenticationMode { get; set; } = AuthenticationMode.AuthorizationToken;
@@ -44,7 +48,7 @@ namespace Xamarin.Cognitive.BingSpeech.Sample
 				throw new Exception ("Get a Bing Speech API key here: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/speech-api/");
 			}
 
-			speechClient = new BingSpeechApiClient (Keys.BingSpeech.SubscriptionKey);
+			speechClient = new BingSpeechApiClient (Keys.BingSpeech.SubscriptionKey, SpeechRegion);
 
 			//	if you need custom endpoint(s) you can do this:
 			//speechClient.SpeechEndpoint = new Endpoint ("westus.stt.speech.microsoft.com", "/speech/recognition");
@@ -69,6 +73,21 @@ namespace Xamarin.Cognitive.BingSpeech.Sample
 			}
 		}
 
+		private void SpeechRegionPicker_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			//update client to the new region
+			speechClient.SpeechRegion = SpeechRegion;
+
+			//clear existing token, the region has changed
+			speechClient.ClearAuthToken();
+
+			//is the auth switch set to true?
+			if (AuthSwitch.IsToggled)
+			{
+				//get a new token for the selected region
+				Task.Run(() => speechClient.AuthenticateWithToken());
+			}
+		}
 
 		private void AuthSwitch_Toggled (object sender, ToggledEventArgs e)
 		{
@@ -83,7 +102,6 @@ namespace Xamarin.Cognitive.BingSpeech.Sample
 				speechClient.ClearAuthToken ();
 			}
 		}
-
 
 		async void Record_Clicked (object sender, EventArgs e)
 		{

--- a/Sample/Xamarin.Cognitive.BingSpeech.Sample/Xamarin.Cognitive.BingSpeech.Sample.csproj
+++ b/Sample/Xamarin.Cognitive.BingSpeech.Sample/Xamarin.Cognitive.BingSpeech.Sample.csproj
@@ -6,8 +6,11 @@
 
   <ItemGroup>
     <PackageReference Include="Plugin.AudioRecorder" Version="1.1.0" />
-    <PackageReference Include="Xamarin.Cognitive.BingSpeech" Version="2.1.2" />
     <PackageReference Include="Xamarin.Forms" Version="3.1.0.697729" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Xamarin.Cognitive.BingSpeech\Xamarin.Cognitive.BingSpeech.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Xamarin.Cognitive.BingSpeech/AuthenticationClient.cs
+++ b/Xamarin.Cognitive.BingSpeech/AuthenticationClient.cs
@@ -12,6 +12,7 @@ namespace Xamarin.Cognitive.BingSpeech
 	{
 		readonly string subscriptionKey;
 		readonly Endpoint authEndpoint;
+		readonly SpeechRegion speechRegion;
 		readonly HttpClient client;
 
 		internal string Token { get; private set; }
@@ -21,13 +22,14 @@ namespace Xamarin.Cognitive.BingSpeech
 		/// </summary>
 		/// <param name="authEndpoint">The auth endpoint to get an auth token from.</param>
 		/// <param name="subscriptionKey">Subscription identifier.</param>
-		public AuthenticationClient (Endpoint authEndpoint, string subscriptionKey)
+		public AuthenticationClient (Endpoint authEndpoint, string subscriptionKey, SpeechRegion speechRegion)
 		{
 			this.authEndpoint = authEndpoint;
 			this.subscriptionKey = subscriptionKey;
+			this.speechRegion = speechRegion;
 
 			client = new HttpClient ();
-			client.DefaultRequestHeaders.Add (Constants.Keys.SubscriptionKey, subscriptionKey);
+			client.DefaultRequestHeaders.Add (Constants.Keys.SubscriptionKey, this.subscriptionKey);
 		}
 
 		/// <summary>
@@ -53,9 +55,9 @@ namespace Xamarin.Cognitive.BingSpeech
 			try
 			{
 				var uriBuilder = new UriBuilder (authEndpoint.Protocol,
-												 authEndpoint.Host,
-												 authEndpoint.Port,
-												 authEndpoint.Path);
+												 $"{speechRegion.ToString().ToLower()}.{authEndpoint.Host}",
+												authEndpoint.Port,
+												authEndpoint.Path);
 
 				Debug.WriteLine ($"{DateTime.Now} :: Request Uri: {uriBuilder.Uri}");
 

--- a/Xamarin.Cognitive.BingSpeech/Model/SpeechRegion.cs
+++ b/Xamarin.Cognitive.BingSpeech/Model/SpeechRegion.cs
@@ -1,0 +1,24 @@
+namespace Xamarin.Cognitive.BingSpeech
+{
+	public enum SpeechRegion
+	{
+		AustraliaEast,
+		CanadaCentral,
+		CentralIndia,
+		CentralUS,
+		EastAsia,
+		EastUS,
+		EastUS2,
+		FranceCentral,
+		JapanEast,
+		KoreaCentral,
+		NorthEurope,
+		NorthCentralUS,
+		SouthEastAsia,
+		SouthcentralUS,
+		UKSouth,
+		WestEurope,
+		WestUS,
+		WestUS2	
+	}
+}

--- a/Xamarin.Cognitive.BingSpeech/Values/Endpoints.cs
+++ b/Xamarin.Cognitive.BingSpeech/Values/Endpoints.cs
@@ -2,8 +2,8 @@ namespace Xamarin.Cognitive.BingSpeech
 {
 	static class Endpoints
 	{
-		public static Endpoint Authentication = new Endpoint ("api.cognitive.microsoft.com", "/sts/v1.0/issueToken");
+		public static Endpoint Authentication = new Endpoint("api.cognitive.microsoft.com", "/sts/v1.0/issueToken");
 
-		public static Endpoint BingSpeechApi = new Endpoint ("speech.platform.bing.com", "/speech/recognition");
+		public static Endpoint SpeechServiceApi = new Endpoint("stt.speech.microsoft.com", "/speech/recognition");
 	}
 }

--- a/Xamarin.Cognitive.BingSpeech/Xamarin.Cognitive.BingSpeech.csproj
+++ b/Xamarin.Cognitive.BingSpeech/Xamarin.Cognitive.BingSpeech.csproj
@@ -3,8 +3,10 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Remove="Values\Endpoint.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.5-dev.1" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />


### PR DESCRIPTION
I was only able to test Android Application with the changes.

I also removed references to the old NuGet package and instead directly references the project.

Changes overall were minor.
Fixed bug in BingSpeechApiClient where local variables were not being passed into AuthenticationClient CTOR

